### PR TITLE
Fix lognl term and PSD estimation

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -939,7 +939,8 @@ class GatedGaussianNoise(BaseGaussianNoise):
             gates=self.gates, **self.static_params)
 
 
-    @BaseData.data.setter(self, data):
+    @BaseData.data.setter
+    def data(self, data):
         """Store a copy of the FD and TD data."""
         BaseData.data.fset(self, data)
         # store the td version


### PR DESCRIPTION
Does two primary things:
 * If the gate changes at all, the log of the noise likelihood will not be the same. This means that, unlike the normal gaussian model, we cannot use log of the likelihood ratio (loglr) as the a substitute for the likelihood, since the denominator in the ratio (the noise likelihood) is no longer constant. This patch fixes that by calculating the lognl on each new parameter point.
 * This model requires that the PSD being estimated down to 0Hz. However, there appears to be some sort of  bug when estimating the PSD down to 0Hz using the strain module's `from_cli` functions, as the normal Gaussian model does. For now, this just hard-codes in to use `TimeSeries.filter_psd` method down to 0Hz. Will need to properly fix this before merging in to pycbc's master branch.