### PR TITLE
Allow different polarization for different waveforms; some plots

### DIFF
--- a/bin/inference/pycbc_inference_plot_fd_waveforms
+++ b/bin/inference/pycbc_inference_plot_fd_waveforms
@@ -1,0 +1,200 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2020 Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Makes a plot of recovered waveforms from an inference analysis."""
+
+
+import argparse
+import logging
+import sys
+
+import numpy
+
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot
+
+import pycbc
+import pycbc.version
+from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
+from pycbc.results import metadata
+from pycbc import __version__
+from pycbc.inference import (io, models)
+
+# add options to command line
+parser = argparse.ArgumentParser()
+# program-specific
+parser.add_argument("--input-file", required=True,
+                    help="Path to input file. Must be either an inference "
+                         "file or a posterior file.")
+parser.add_argument("--output-file", type=str, required=True,
+                    help="Path to output plot.")
+parser.add_argument("--plot", required=True, nargs="+",
+                    choices=["waveforms", "data", "residual", "injection",
+                             "gated_waveforms", "gated_data", "gated_residual",
+                             "gated_injection"],
+                    help="What to plot: a waveform, the data, and/or the "
+                         "injection (if it exists). In addition, if the "
+                         "model used is GatedGaussian, can also plot gated "
+                         "versions.")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--whiten", action="store_true", default=False,
+                   help="Plot whitened data/waveforms/injection.")
+group.add_argument("--overwhiten", action="store_true", default=False,
+                   help="Plot over-whitened data/waveforms/injection.")
+parser.add_argument("--waveform-selection", choices=["maxl"], default="maxl",
+                    help="How to select the waveform for plotting. Default is "
+                         "maxl (= maximum likelihood).")
+parser.add_argument("--time-slice", nargs=2, type=float)
+parser.add_argument("--reference-time",
+                    help="Reference time for the time-slice. Can specify a "
+                         "GPS time, 'trigger-time', or 'maxltc'. If not "
+                         "provided, the x-axis will just be in terms of GPS " 
+                         "seconds.")
+parser.add_argument("--xmin", type=float)
+parser.add_argument("--xmax", type=float)
+parser.add_argument("--ymin", type=float)
+parser.add_argument("--ymax", type=float)
+parser.add_argument('--dpi', type=int, default=200,
+                    help="Set the DPI of the plot. Default is 200.")
+# boiler plate stuff
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
+parser.add_argument("--verbose", action="store_true", default=False,
+                    help="Be verbose")
+# style option
+add_style_opt_to_parser(parser)
+
+# parse command line
+opts = parser.parse_args()
+
+# set mpl style
+set_style_from_cli(opts)
+
+# set logging
+pycbc.init_logging(opts.verbose)
+
+if opts.whiten:
+    whiten = 1
+elif opts.overwhiten:
+    whiten = 2
+else:
+    whiten = False
+    
+logging.info("Setting up the model")
+fp = io.loadfile(opts.input_file, 'r')
+data = fp.read_data()
+psds = fp.read_psds()
+cp = fp.read_config_file()
+
+model = models.read_from_config(cp, data=data, psds=psds)
+
+if not (opts.plot == ["data"] and opts.reference_time != "maxltc"):
+    # load samples
+    logging.info("Loading samples")
+    samples = fp.read_samples(list(fp['samples'].keys()))
+    if opts.waveform_selection == "maxl":
+        idx = samples['loglikelihood'].argmax()
+    else:
+        raise ValueError("Unrecoganized waveform selection option {}"
+                         .format(opts.waveform_selection))
+    params = {p: samples[p][idx] for p in samples.fieldnames}
+    # ensure sampling transforms are turned off
+    model.sampling_transforms = None
+    model.update(**params)
+    # call the likelihood to trigger any sort of waveform transforms
+    _ = model.loglikelihood
+fp.close()
+
+if opts.reference_time == "maxltc":
+    tref = model.current_params['tc']
+elif opts.reference_time == "trigger_time":
+    # try to get the trigger time from the config file
+    tref = float(cp.get("data", "trigger-time"))
+elif opts.reference_time is not None:
+    tref = float(opts.reference_time)
+else:
+    tref = 0
+
+# load the waveforms and data
+logging.info("Loading frequency series")
+frequency_series = {}
+for plttype in opts.plot:
+    thisfs = {}
+    if plttype == "injection":
+        injset = inject.InjectionSet(opts.input_file, hdf_group='injections')
+        inj = injset.table[0]
+        for det, d in data.items():
+            h = injset.make_strain_from_inj_object(inj, d.delta_t, det)
+            if opts.time_slice is not None:
+                h = h.time_slice(opts.time_slice[0]+tref,
+                                 opts.time_slice[1]+tref)
+            thisfs[det] = h.to_frequencyseries()
+    else:
+        fds = getattr(model, 'get_{}'.format(plttype))(whiten=whiten)
+        for det, dtilde in fds.items():
+            if opts.time_slice is not None:
+                d = dtilde.to_timeseries().time_slice(
+                    opts.time_slice[0]+tref, opts.time_slice[1]+tref)
+                dtilde = d.to_frequencyseries()
+            thisfs[det] = dtilde
+    frequency_series[plttype] = thisfs
+
+logging.info("Plotting")
+ncols = len(data.keys())
+fwidth = ncols*3
+fig, axes = pyplot.subplots(ncols=ncols, figsize=(fwidth, 3))
+for ii, det in enumerate(data.keys()):
+    logging.info(det)
+    ax = axes[ii]
+    ax.loglog()
+    for plttype in frequency_series:
+        lbl = plttype.replace('_', ' ')
+        lbl = lbl.replace("waveforms", opts.waveform_selection)
+        x = frequency_series[plttype][det]
+        ax.plot(x.sample_frequencies, abs(x), lw=2, label=lbl)
+        if opts.xmin is not None or opts.xmax is not None:
+            ax.set_xlim(xmin=opts.xmin, xmax=opts.xmax)
+        if opts.ymin is not None or opts.ymax is not None:
+            ax.set_ylim(ymin=opts.ymin, ymax=opts.ymax)
+    if ii == 0:
+        # add the y label to the first axis
+        if whiten == 1:
+            ax.set_ylabel(r"whitened $\tilde{s}$")
+        elif whiten == 2:
+            ax.set_ylabel(r"over-whitened $\tilde{s}$")
+        else:
+            ax.set_ylabel(r"$\tilde{s}$")
+    ax.set_title(det)
+    ax.set_xlabel("frequency (Hz)")
+    ax.grid(which='both')
+# add the legend to the last axis
+ax.legend()
+
+# set DPI
+fig.set_dpi(opts.dpi)
+
+# save
+metadata.save_fig_with_metadata(
+                 fig, opts.output_file,
+                 cmd=" ".join(sys.argv),
+                 title="Waveforms",
+                 caption="Waveforms and data.",
+                 fig_kwds={'bbox_inches': 'tight'})
+
+# finish
+logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -58,9 +58,12 @@ parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
-parser.add_argument("--plot-prior", nargs="+", type=str,
-                    help="Plot the prior on the 1D marginal plots using the "
-                         "given config file(s).")
+parser.add_argument("--plot-prior", nargs="*", type=str,
+                    help="Plot the prior on the 1D marginal plots. If no "
+                         "files are given, this will try to load the prior "
+                         "from the config file stored in the first given "
+                         "input file. If the config file is not in the input "
+                         "file, you must provide the prior config file(s).")
 parser.add_argument("--prior-nsamples", type=int, default=10000,
                     help="The number of samples to use for plotting the "
                          "prior. Default is 10000.")
@@ -128,7 +131,11 @@ if opts.plot_prior is not None:
                          "either turn on --plot-marginal, or turn off "
                          "--plot-prior")
     logging.info("Loading prior")
-    cp = WorkflowConfigParser(opts.plot_prior)
+    if opts.plot_prior == []:
+        # try loading the config file from the input
+        cp = fps[0].read_config_file()
+    else:
+        cp = WorkflowConfigParser(opts.plot_prior)
     prior = option_utils.prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
@@ -255,7 +262,7 @@ for (i, s) in enumerate(samples):
                     expected_parameters_color=opts.expected_parameters_color)
 
 # plot the prior
-if opts.plot_prior:
+if opts.plot_prior is not None:
     if len(opts.input_file) > 1:
         hist_color = next(colors)
     fig, axis_dict = create_multidim_plot(

--- a/bin/inference/pycbc_inference_plot_waveforms
+++ b/bin/inference/pycbc_inference_plot_waveforms
@@ -1,0 +1,200 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2020 Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Makes a plot of recovered waveforms from an inference analysis."""
+
+
+import argparse
+import logging
+import sys
+
+import numpy
+
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot
+
+import pycbc
+import pycbc.version
+from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
+from pycbc.results import metadata
+from pycbc import __version__
+from pycbc.inference import (io, models)
+
+# add options to command line
+parser = argparse.ArgumentParser()
+# program-specific
+parser.add_argument("--input-file", required=True,
+                    help="Path to input file. Must be either an inference "
+                         "file or a posterior file.")
+parser.add_argument("--output-file", type=str, required=True,
+                    help="Path to output plot.")
+parser.add_argument("--plot", required=True, nargs="+",
+                    choices=["waveforms", "data", "residual", "injection",
+                             "gated_waveforms", "gated_data", "gated_residual",
+                             "gated_injection"],
+                    help="What to plot: a waveform, the data, and/or the "
+                         "injection (if it exists). In addition, if the "
+                         "model used is GatedGaussian, can also plot gated "
+                         "versions.")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--whiten", action="store_true", default=False,
+                   help="Plot whitened data/waveforms/injection.")
+group.add_argument("--overwhiten", action="store_true", default=False,
+                   help="Plot over-whitened data/waveforms/injection.")
+parser.add_argument("--waveform-selection", choices=["maxl"], default="maxl",
+                    help="How to select the waveform for plotting. Default is "
+                         "maxl (= maximum likelihood).")
+parser.add_argument("--reference-time",
+                    help="Reference time for the x-axis. Can either specify a "
+                         "GPS time, 'trigger-time', or 'maxltc'. If not "
+                         "provided, the x-axis will just be in terms of GPS " 
+                         "seconds.")
+parser.add_argument("--xmin", type=float)
+parser.add_argument("--xmax", type=float)
+parser.add_argument("--ymin", type=float)
+parser.add_argument("--ymax", type=float)
+parser.add_argument('--dpi', type=int, default=200,
+                    help="Set the DPI of the plot. Default is 200.")
+# boiler plate stuff
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
+parser.add_argument("--verbose", action="store_true", default=False,
+                    help="Be verbose")
+# style option
+add_style_opt_to_parser(parser)
+
+# parse command line
+opts = parser.parse_args()
+
+# set mpl style
+set_style_from_cli(opts)
+
+# set logging
+pycbc.init_logging(opts.verbose)
+
+if opts.whiten:
+    whiten = 1
+elif opts.overwhiten:
+    whiten = 2
+else:
+    whiten = False
+    
+logging.info("Setting up the model")
+fp = io.loadfile(opts.input_file, 'r')
+data = fp.read_data()
+psds = fp.read_psds()
+cp = fp.read_config_file()
+
+model = models.read_from_config(cp, data=data, psds=psds)
+
+if not (opts.plot == ["data"] and opts.reference_time != "maxltc"):
+    # load samples
+    logging.info("Loading samples")
+    samples = fp.read_samples(list(fp['samples'].keys()))
+    if opts.waveform_selection == "maxl":
+        idx = samples['loglikelihood'].argmax()
+    else:
+        raise ValueError("Unrecoganized waveform selection option {}"
+                         .format(opts.waveform_selection))
+    params = {p: samples[p][idx] for p in samples.fieldnames}
+    # ensure sampling transforms are turned off
+    model.sampling_transforms = None
+    model.update(**params)
+    # call the likelihood to trigger any sort of waveform transforms
+    _ = model.loglikelihood
+fp.close()
+
+if opts.reference_time == "maxltc":
+    tref = model.current_params['tc']
+elif opts.reference_time == "trigger_time":
+    # try to get the trigger time from the config file
+    tref = float(cp.get("data", "trigger-time"))
+elif opts.reference_time is not None:
+    tref = float(opts.reference_time)
+else:
+    tref = 0
+
+# load the waveforms and data
+logging.info("Loading time series")
+timeseries = {}
+for plttype in opts.plot:
+    thists = {}
+    if plttype == "injection":
+        injset = inject.InjectionSet(opts.input_file, hdf_group='injections')
+        inj = injset.table[0]
+        for det, d in data.items():
+            h = injset.make_strain_from_inj_object(inj, d.delta_t, det)
+            thists[det] = h
+    else:
+        fds = getattr(model, 'get_{}'.format(plttype))(whiten=whiten)
+        for det, dtilde in fds.items():
+            d = dtilde.to_timeseries()
+            thists[det] = d 
+    timeseries[plttype] = thists
+
+logging.info("Plotting")
+nrows = len(data.keys())
+fheight = nrows*3
+fig, axes = pyplot.subplots(nrows=nrows, figsize=(8, fheight))
+for ii, det in enumerate(data.keys()):
+    logging.info(det)
+    ax = axes[ii]
+    for plttype in timeseries:
+        lbl = plttype.replace('_', ' ')
+        lbl = lbl.replace("waveforms", opts.waveform_selection)
+        x = timeseries[plttype][det]
+        if opts.xmin is not None or opts.xmax is not None:
+            xmin = opts.xmin
+            xmax = opts.xmax
+            if xmin is None:
+                xmin = x.start_time
+            if xmax is None:
+                xmax = x.end_time
+            x = x.time_slice(xmin+tref, xmax+tref)
+        ax.plot(x.sample_times-tref, x, lw=2, label=lbl)
+        if opts.xmin is not None or opts.xmax is not None:
+            ax.set_xlim(xmin=opts.xmin, xmax=opts.xmax)
+        if opts.ymin is not None or opts.ymax is not None:
+            ax.set_ylim(ymin=opts.ymin, ymax=opts.ymax)
+    if whiten == 1:
+        ax.set_ylabel("{} whitened strain".format(det))
+    elif whiten == 2:
+        ax.set_ylabel("{} over-whitened strain".format(det))
+    else:
+        ax.set_ylabel("{} strain".format(det))
+    if ii == 0:
+        ax.legend()
+# add the xlabel to the last axis
+if tref:
+    ax.set_xlabel("GPS time - {} (s)".format(tref))
+else:
+    ax.set_label("time (s)")
+
+# set DPI
+fig.set_dpi(opts.dpi)
+
+# save
+metadata.save_fig_with_metadata(
+                 fig, opts.output_file,
+                 cmd=" ".join(sys.argv),
+                 title="Waveforms",
+                 caption="Waveforms and data.",
+                 fig_kwds={'bbox_inches': 'tight'})
+
+# finish
+logging.info("Done")

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -942,7 +942,8 @@ def get_lm_f0tau_allmodes(mass, spin, modes):
     return f0, tau
 
 
-def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
+def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1,
+                              n=None):
     """Returns QNM frequency for the given mass and spin and mode.
 
     Parameters
@@ -957,6 +958,8 @@ def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
         m-index of the harmonic. Default is 2.
     nmodes : int, optional
         The number of overtones to generate. Default is 1.
+    n : int, optional
+        Only retrieve the specified overtone. Overrides the ``nmodes``.
 
     Returns
     -------
@@ -967,10 +970,16 @@ def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
         ``[input shape x] nmodes``, where ``input shape`` is the broadcasted
         shape of the inputs.
     """
-    return get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[0]
+    if n is not None:
+        nmodes = n + 1
+    out = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[0]
+    if n is not None:
+        out = out[..., n]
+    return out
 
 
-def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
+def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1,
+                             n=None):
     """Returns QNM damping time for the given mass and spin and mode.
 
     Parameters
@@ -995,7 +1004,12 @@ def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
         ``[input shape x] nmodes``, where ``input shape`` is the broadcasted
         shape of the inputs.
     """
-    return get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[1]
+    if n is not None:
+        nmodes = n + 1
+    out = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[1]
+    if n is not None:
+        out = out[..., n]
+    return out
 
 
 # The following are from Table VIII, IX, X of Berti et al.,

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -46,6 +46,7 @@ from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
 from pycbc.io import (dump_state, load_state)
 from pycbc.workflow import WorkflowConfigParser
+from pycbc.types import FrequencySeries
 
 
 def format_attr(val):
@@ -913,3 +914,44 @@ class BaseInferenceFile(h5py.File):
             cp.read_file(cf)
             return cp
         return cf
+
+    def read_data(self):
+        """Loads the data stored in the file as a FrequencySeries.
+
+        Only works for models that store data as a frequency series in
+        ``data/DET/stilde``. A ``KeyError`` will be raised if the model used
+        did not store data in that path.
+
+        Returns
+        -------
+        dict :
+            Dictionary of detector name -> FrequencySeries.
+        """
+        data = {}
+        fmt = 'data/{}/stilde'
+        for det in self['data'].keys():
+            group = self[fmt.format(det)]
+            data[det] = FrequencySeries(
+                group[()], delta_f=group.attrs['delta_f'],
+                epoch=group.attrs['epoch'])
+        return data
+
+    def read_psds(self):
+        """Loads the PSDs stored in the file as a FrequencySeries.
+
+        Only works for models that store PSDs in
+        ``data/DET/psds/0``. A ``KeyError`` will be raised if the model used
+        did not store PSDs in that path.
+
+        Returns
+        -------
+        dict :
+            Dictionary of detector name -> FrequencySeries.
+        """
+        psds = {}
+        fmt = 'data/{}/psds/0'
+        for det in self['data'].keys():
+            group = self[fmt.format(det)]
+            psds[det] = FrequencySeries(
+                group[()], delta_f=group.attrs['delta_f'])
+        return psds

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1259,14 +1259,17 @@ class GatedGaussianNoise(BaseGaussianNoise):
             # calculate the residual
             data = self.td_data[det]
             ht = h.to_timeseries()
-            res = data - ht
-            gated_res = res.gate(gatestartdelay + dgatedelay/2,
-                                 window=dgatedelay/2, copy=True,
-                                 invpsd=invpsd, method='paint')
-            proj = gated_res.proj
-            lindex, rindex = gated_res.projslc
-            ht[lindex:rindex] *= 0.
-            ht[lindex:rindex] -= proj
+            ht = ht.gate(gatestartdelay + dgatedelay/2,
+                         window=dgatedelay/2, copy=False,
+                         invpsd=invpsd, method='paint')
+            #res = data - ht
+            #gated_res = res.gate(gatestartdelay + dgatedelay/2,
+            #                     window=dgatedelay/2, copy=True,
+            #                     invpsd=invpsd, method='paint')
+            #proj = gated_res.proj
+            #lindex, rindex = gated_res.projslc
+            #ht[lindex:rindex] *= 0.
+            #ht[lindex:rindex] -= proj
             h = ht.to_frequencyseries()
             if whiten == 2:
                 h *= invpsd
@@ -1328,31 +1331,47 @@ class GatedGaussianNoise(BaseGaussianNoise):
         
     def get_gated_data(self, whiten=False):
         gate_times = self.get_gate_times()
-        params = self.current_params
-        wfs = self.waveform_generator.generate(**params)
-        data = {det: d.copy() for det, d in self.td_data.items()}
-        for det, d in data.items():
+        out = {}
+        for det, d in self.td_data.items():
             invpsd = self._invpsds[det]
             gatestartdelay, dgatedelay = gate_times[det]
-            # calculate the residual
-            h = wfs[det]
-            ht = h.to_timeseries()
-            res = d - ht
-            rtilde = res.to_frequencyseries()
-            gated_res = res.gate(gatestartdelay + dgatedelay/2,
-                                 window=dgatedelay/2, copy=True,
-                                 invpsd=invpsd, method='paint')
-            proj = gated_res.proj
-            lindex, rindex = gated_res.projslc
-            d[lindex:rindex] *= 0.
-            d[lindex:rindex] -= proj
+            d = d.gate(gatestartdelay + dgatedelay/2,
+                       window=dgatedelay/2, copy=True,
+                       invpsd=invpsd, method='paint')
             dtilde = d.to_frequencyseries()
             if whiten == 2:
                 dtilde *= invpsd
             elif whiten:
                 dtilde *= invpsd**0.5
-            data[det] = dtilde
-        return data
+            out[det] = dtilde
+        return out
+    #def get_gated_data(self, whiten=False):
+    #    gate_times = self.get_gate_times()
+    #    params = self.current_params
+    #    wfs = self.waveform_generator.generate(**params)
+    #    data = {det: d.copy() for det, d in self.td_data.items()}
+    #    for det, d in data.items():
+    #        invpsd = self._invpsds[det]
+    #        gatestartdelay, dgatedelay = gate_times[det]
+    #        # calculate the residual
+    #        h = wfs[det]
+    #        ht = h.to_timeseries()
+    #        res = d - ht
+    #        rtilde = res.to_frequencyseries()
+    #        gated_res = res.gate(gatestartdelay + dgatedelay/2,
+    #                             window=dgatedelay/2, copy=True,
+    #                             invpsd=invpsd, method='paint')
+    #        proj = gated_res.proj
+    #        lindex, rindex = gated_res.projslc
+    #        d[lindex:rindex] *= 0.
+    #        d[lindex:rindex] -= proj
+    #        dtilde = d.to_frequencyseries()
+    #        if whiten == 2:
+    #            dtilde *= invpsd
+    #        elif whiten:
+    #            dtilde *= invpsd**0.5
+    #        data[det] = dtilde
+    #    return data
 
     def write_metadata(self, fp):
         """Adds writing the psds.

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -466,7 +466,8 @@ class BaseGaussianNoise(BaseDataModel):
                                                         self._f_upper[det]
 
     @classmethod
-    def from_config(cls, cp, data_section='data', **kwargs):
+    def from_config(cls, cp, data_section='data', data=None, psds=None,
+                    **kwargs):
         r"""Initializes an instance of this class from the given config file.
 
         In addition to ``[model]``, a ``data_section`` (default ``[data]``)
@@ -557,25 +558,27 @@ class BaseGaussianNoise(BaseDataModel):
         # load the data
         opts = data_opts_from_config(cp, data_section,
                                      args['low_frequency_cutoff'])
-        strain_dict, psd_strain_dict = data_from_cli(opts, **data_args)
-        # convert to frequency domain and get psds
-        stilde_dict, psds = fd_data_from_strain_dict(opts, strain_dict,
-                                                     psd_strain_dict)
-        logging.info('Calculating psds using filter psd')
-        psds = {}
-        for det, d in psd_strain_dict.items():
-            psds[det] = d.filter_psd(opts.psd_segment_length[det], 
-                                     strain_dict[det].delta_f, 0.)
-        # save the psd data segments if the psd was estimated from data
-        if opts.psd_estimation is not None:
-            _tdict = psd_strain_dict or strain_dict
-            for det in psds:
-                psds[det].psd_segment = (_tdict[det].start_time,
-                                         _tdict[det].end_time)
-        # gate overwhitened if desired
-        if opts.gate_overwhitened and opts.gate is not None:
-            stilde_dict = gate_overwhitened_data(stilde_dict, psds, opts.gate)
-        args.update({'data': stilde_dict, 'psds': psds})
+        if data is None or psds is None:
+            strain_dict, psd_strain_dict = data_from_cli(opts, **data_args)
+            # convert to frequency domain and get psds
+            stilde_dict, psds = fd_data_from_strain_dict(opts, strain_dict,
+                                                         psd_strain_dict)
+            logging.info('Calculating psds using filter psd')
+            psds = {}
+            for det, d in psd_strain_dict.items():
+                psds[det] = d.filter_psd(opts.psd_segment_length[det], 
+                                         strain_dict[det].delta_f, 0.)
+            # save the psd data segments if the psd was estimated from data
+            if opts.psd_estimation is not None:
+                _tdict = psd_strain_dict or strain_dict
+                for det in psds:
+                    psds[det].psd_segment = (_tdict[det].start_time,
+                                             _tdict[det].end_time)
+            # gate overwhitened if desired
+            if opts.gate_overwhitened and opts.gate is not None:
+                stilde_dict = gate_overwhitened_data(stilde_dict, psds, opts.gate)
+            data = stilde_dict
+        args.update({'data': data, 'psds': psds})
         # any extra args
         args.update(cls.extra_args_from_config(cp, "model",
                                                skip_args=ignore_args))

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1256,20 +1256,11 @@ class GatedGaussianNoise(BaseGaussianNoise):
         for det, h in wfs.items():
             invpsd = self._invpsds[det]
             gatestartdelay, dgatedelay = gate_times[det]
-            # calculate the residual
             data = self.td_data[det]
             ht = h.to_timeseries()
             ht = ht.gate(gatestartdelay + dgatedelay/2,
                          window=dgatedelay/2, copy=False,
                          invpsd=invpsd, method='paint')
-            #res = data - ht
-            #gated_res = res.gate(gatestartdelay + dgatedelay/2,
-            #                     window=dgatedelay/2, copy=True,
-            #                     invpsd=invpsd, method='paint')
-            #proj = gated_res.proj
-            #lindex, rindex = gated_res.projslc
-            #ht[lindex:rindex] *= 0.
-            #ht[lindex:rindex] -= proj
             h = ht.to_frequencyseries()
             if whiten == 2:
                 h *= invpsd
@@ -1284,7 +1275,6 @@ class GatedGaussianNoise(BaseGaussianNoise):
         out = {}
         for det, h in wfs.items():
             invpsd = self._invpsds[det]
-            # calculate the residual
             d = self.data[det]
             res = d - h
             if whiten == 2:
@@ -1302,7 +1292,6 @@ class GatedGaussianNoise(BaseGaussianNoise):
         for det, h in wfs.items():
             invpsd = self._invpsds[det]
             gatestartdelay, dgatedelay = gate_times[det]
-            # calculate the residual
             data = self.td_data[det]
             ht = h.to_timeseries()
             res = data - ht
@@ -1345,33 +1334,6 @@ class GatedGaussianNoise(BaseGaussianNoise):
                 dtilde *= invpsd**0.5
             out[det] = dtilde
         return out
-    #def get_gated_data(self, whiten=False):
-    #    gate_times = self.get_gate_times()
-    #    params = self.current_params
-    #    wfs = self.waveform_generator.generate(**params)
-    #    data = {det: d.copy() for det, d in self.td_data.items()}
-    #    for det, d in data.items():
-    #        invpsd = self._invpsds[det]
-    #        gatestartdelay, dgatedelay = gate_times[det]
-    #        # calculate the residual
-    #        h = wfs[det]
-    #        ht = h.to_timeseries()
-    #        res = d - ht
-    #        rtilde = res.to_frequencyseries()
-    #        gated_res = res.gate(gatestartdelay + dgatedelay/2,
-    #                             window=dgatedelay/2, copy=True,
-    #                             invpsd=invpsd, method='paint')
-    #        proj = gated_res.proj
-    #        lindex, rindex = gated_res.projslc
-    #        d[lindex:rindex] *= 0.
-    #        d[lindex:rindex] -= proj
-    #        dtilde = d.to_frequencyseries()
-    #        if whiten == 2:
-    #            dtilde *= invpsd
-    #        elif whiten:
-    #            dtilde *= invpsd**0.5
-    #        data[det] = dtilde
-    #    return data
 
     def write_metadata(self, fp):
         """Adds writing the psds.

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -282,7 +282,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
         else:
             lw = 2
         ct = ax.contour(X, Y, Z, s, colors=contour_color, linewidths=lw,
-                        zorder=3)
+                        linestyles=['dashed', 'solid'], zorder=3)
         # label contours
         lbls = ['{p}%'.format(p=int(p)) for p in (100. - percentiles)]
         fmt = dict(zip(ct.levels, lbls))


### PR DESCRIPTION
A few things:
- Adds ability to specify different polarizations for each mode. Done by specifying `pollmn`, e.g., `pol330`, parameters for each mode. If given, the spherical harmonics will not be used.
- Adds a couple of scripts to plot the maxL waveform; one script does it in the time domain, the other in the frequency domain.
- Adds the ability to specify a single overtone in `(freq|tau)_from_final_mass_spin`.
- Makes the 90% contours dashed lines in plot posterior.
